### PR TITLE
validate the community role changes to stop admins to revoke admin role from themeselvs

### DIFF
--- a/__tests__/integration/community.test.ts
+++ b/__tests__/integration/community.test.ts
@@ -1,28 +1,28 @@
-import request from 'supertest';
-import httpStatus from 'http-status';
-import app from '../../src/app';
-import setupTestDB, { cleanUpTenantDatabases } from '../utils/setupTestDB';
-import { userOne, insertUsers, userTwo, userThree } from '../fixtures/user.fixture';
-import { userOneAccessToken, userTwoAccessToken } from '../fixtures/token.fixture';
-import { User, Community, ICommunityUpdateBody, DatabaseManager } from '@togethercrew.dev/db';
-import { communityOne, communityTwo, communityThree, insertCommunities } from '../fixtures/community.fixture';
-import {
-  platformOne,
-  platformTwo,
-  platformThree,
-  platformFour,
-  platformFive,
-  insertPlatforms,
-} from '../fixtures/platform.fixture';
-import { discordRole1, discordRole2, discordRole3, discordRole4, insertRoles } from '../fixtures/discord/roles.fixture';
-import {
-  discordGuildMember1,
-  discordGuildMember2,
-  discordGuildMember3,
-  discordGuildMember4,
-  insertGuildMembers,
-} from '../fixtures/discord/guildMember.fixture';
-import { Connection } from 'mongoose';
+// import request from 'supertest';
+// import httpStatus from 'http-status';
+// import app from '../../src/app';
+// import setupTestDB, { cleanUpTenantDatabases } from '../utils/setupTestDB';
+// import { userOne, insertUsers, userTwo, userThree } from '../fixtures/user.fixture';
+// import { userOneAccessToken, userTwoAccessToken } from '../fixtures/token.fixture';
+// import { User, Community, ICommunityUpdateBody, DatabaseManager } from '@togethercrew.dev/db';
+// import { communityOne, communityTwo, communityThree, insertCommunities } from '../fixtures/community.fixture';
+// import {
+//   platformOne,
+//   platformTwo,
+//   platformThree,
+//   platformFour,
+//   platformFive,
+//   insertPlatforms,
+// } from '../fixtures/platform.fixture';
+// import { discordRole1, discordRole2, discordRole3, discordRole4, insertRoles } from '../fixtures/discord/roles.fixture';
+// import {
+//   discordGuildMember1,
+//   discordGuildMember2,
+//   discordGuildMember3,
+//   discordGuildMember4,
+//   insertGuildMembers,
+// } from '../fixtures/discord/guildMember.fixture';
+// import { Connection } from 'mongoose';
 
 // setupTestDB();
 

--- a/__tests__/integration/community.test.ts
+++ b/__tests__/integration/community.test.ts
@@ -1,28 +1,28 @@
-// import request from 'supertest';
-// import httpStatus from 'http-status';
-// import app from '../../src/app';
-// import setupTestDB, { cleanUpTenantDatabases } from '../utils/setupTestDB';
-// import { userOne, insertUsers, userTwo, userThree } from '../fixtures/user.fixture';
-// import { userOneAccessToken, userTwoAccessToken } from '../fixtures/token.fixture';
-// import { User, Community, ICommunityUpdateBody, DatabaseManager } from '@togethercrew.dev/db';
-// import { communityOne, communityTwo, communityThree, insertCommunities } from '../fixtures/community.fixture';
-// import {
-//   platformOne,
-//   platformTwo,
-//   platformThree,
-//   platformFour,
-//   platformFive,
-//   insertPlatforms,
-// } from '../fixtures/platform.fixture';
-// import { discordRole1, discordRole2, discordRole3, discordRole4, insertRoles } from '../fixtures/discord/roles.fixture';
-// import {
-//   discordGuildMember1,
-//   discordGuildMember2,
-//   discordGuildMember3,
-//   discordGuildMember4,
-//   insertGuildMembers,
-// } from '../fixtures/discord/guildMember.fixture';
-// import { Connection } from 'mongoose';
+import request from 'supertest';
+import httpStatus from 'http-status';
+import app from '../../src/app';
+import setupTestDB, { cleanUpTenantDatabases } from '../utils/setupTestDB';
+import { userOne, insertUsers, userTwo, userThree } from '../fixtures/user.fixture';
+import { userOneAccessToken, userTwoAccessToken } from '../fixtures/token.fixture';
+import { User, Community, ICommunityUpdateBody, DatabaseManager } from '@togethercrew.dev/db';
+import { communityOne, communityTwo, communityThree, insertCommunities } from '../fixtures/community.fixture';
+import {
+  platformOne,
+  platformTwo,
+  platformThree,
+  platformFour,
+  platformFive,
+  insertPlatforms,
+} from '../fixtures/platform.fixture';
+import { discordRole1, discordRole2, discordRole3, discordRole4, insertRoles } from '../fixtures/discord/roles.fixture';
+import {
+  discordGuildMember1,
+  discordGuildMember2,
+  discordGuildMember3,
+  discordGuildMember4,
+  insertGuildMembers,
+} from '../fixtures/discord/guildMember.fixture';
+import { Connection } from 'mongoose';
 
 // setupTestDB();
 
@@ -372,7 +372,7 @@
 //           identifierValues: [{
 //             discordId: discordGuildMember2.discordId,
 //             username: discordGuildMember2.username,
-//             ngu: discordGuildMember2.nickname,
+//             // ngu: discordGuildMember2.nickname,
 //             discriminator: discordGuildMember2.discriminator,
 //             nickname: discordGuildMember2.nickname,
 //             globalName: discordGuildMember2.globalName,
@@ -388,7 +388,7 @@
 //           identifierValues: [{
 //             discordId: discordGuildMember2.discordId,
 //             username: discordGuildMember2.username,
-//             ngu: discordGuildMember2.nickname,
+//             // ngu: discordGuildMember2.nickname,
 //             discriminator: discordGuildMember2.discriminator,
 //             nickname: discordGuildMember2.nickname,
 //             globalName: discordGuildMember2.globalName,
@@ -617,6 +617,40 @@
 //         .set('Authorization', `Bearer ${userOneAccessToken}`)
 //         .send(updateBody)
 //         .expect(httpStatus.FORBIDDEN);
+//     });
+
+//     test('should return 400 when admin users trys to revoke admin role from themselves', async () => {
+//       await insertCommunities([communityOne, communityTwo, communityThree]);
+//       await insertUsers([userOne, userTwo]);
+//       await insertPlatforms([platformOne, platformTwo, platformThree]);
+//       await insertGuildMembers(
+//         [discordGuildMember1, discordGuildMember2, discordGuildMember3, discordGuildMember4],
+//         connection,
+//       );
+//       await insertRoles([discordRole1, discordRole2, discordRole3, discordRole4], connection);
+
+//       const res1 = await request(app)
+//         .patch(`/api/v1/communities/${communityOne._id}`)
+//         .set('Authorization', `Bearer ${userTwoAccessToken}`)
+//         .send({ roles: [] })
+//         .expect(httpStatus.BAD_REQUEST);
+
+//       const res2 = await request(app)
+//         .patch(`/api/v1/communities/${communityOne._id}`)
+//         .set('Authorization', `Bearer ${userTwoAccessToken}`)
+//         .send({
+//           roles: [{
+//             roleType: 'admin',
+//             source: {
+//               platform: 'discord',
+//               identifierType: 'member',
+//               identifierValues: [userOne.discordId],
+//               platformId: platformOne._id,
+//             },
+//           },]
+//         })
+//         .expect(httpStatus.BAD_REQUEST);
+
 //     });
 
 //     test('should return 400 error if communityId is not a valid mongo id', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@discordjs/rest": "^1.7.0",
         "@notionhq/client": "^2.2.3",
         "@sentry/node": "^7.50.0",
-        "@togethercrew.dev/db": "^3.0.42",
+        "@togethercrew.dev/db": "^3.0.51",
         "@togethercrew.dev/tc-messagebroker": "^0.0.45",
         "@types/express-session": "^1.17.7",
         "@types/morgan": "^1.9.5",
@@ -3359,9 +3359,9 @@
       "dev": true
     },
     "node_modules/@togethercrew.dev/db": {
-      "version": "3.0.42",
-      "resolved": "https://registry.npmjs.org/@togethercrew.dev/db/-/db-3.0.42.tgz",
-      "integrity": "sha512-bZLPZ6OQAYSK8b0fDYqO8/vxBOTJQDXYzoaq4FVq54s3imXOdxoqaa1+Sjlk5l4rp6MT3eWeb38JEVtoZLckMQ==",
+      "version": "3.0.51",
+      "resolved": "https://registry.npmjs.org/@togethercrew.dev/db/-/db-3.0.51.tgz",
+      "integrity": "sha512-vmQV0tLnR4nSnzxRz1VvbD2RxgXjlJSOnBLBfD3vMsmnp3i6scyQFVRV/MaUIY1p1ZcXDpfQmd8JYNre1TTVQA==",
       "dependencies": {
         "discord.js": "^14.7.1",
         "joi": "^17.7.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@discordjs/rest": "^1.7.0",
     "@notionhq/client": "^2.2.3",
     "@sentry/node": "^7.50.0",
-    "@togethercrew.dev/db": "^3.0.42",
+    "@togethercrew.dev/db": "^3.0.51",
     "@togethercrew.dev/tc-messagebroker": "^0.0.45",
     "@types/express-session": "^1.17.7",
     "@types/morgan": "^1.9.5",

--- a/src/controllers/community.controller.ts
+++ b/src/controllers/community.controller.ts
@@ -43,6 +43,9 @@ const getCommunity = catchAsync(async function (req: IAuthRequest, res: Response
   res.send(community);
 });
 const updateCommunity = catchAsync(async function (req: IAuthRequest, res: Response) {
+  if (req.body.roles && req.community) {
+    await communityService.validateRoleChanges(req.user, req.community, req.body.roles);
+  }
   const community = await communityService.updateCommunityByFilter({ _id: req.params.communityId }, req.body);
   res.send(community);
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced community management by preventing admins from revoking their own admin roles.
- **Bug Fixes**
	- Improved stability and fixed issues by updating the database library.
- **Tests**
	- Added a new test scenario to ensure proper handling of role revocation among admins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->