### PR TITLE
Add temporal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@discordjs/rest": "^1.7.0",
         "@notionhq/client": "^2.2.3",
         "@sentry/node": "^7.50.0",
+        "@temporalio/client": "^1.11.3",
         "@togethercrew.dev/db": "^3.0.72",
         "@togethercrew.dev/tc-messagebroker": "^0.0.50",
         "@types/express-session": "^1.17.7",
@@ -1611,6 +1612,65 @@
         "node": ">=14"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.2.tgz",
+      "integrity": "sha512-bgxdZmgTrJZX50OjyVwz3+mNEnCTNkh3cIqGPWVNeW9jX6bn1ZkU80uPd+67/ZpIJIjRQ9qaHCjhavyoWYxumg==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -2351,6 +2411,15 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
@@ -2423,6 +2492,60 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.0",
@@ -3163,6 +3286,47 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@temporalio/client": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.11.3.tgz",
+      "integrity": "sha512-2x30xAXbUuqelrWe3Vd1FVC0+Z2Cfh6m2W5yDUZBjqTMdNP6qd8nH4S4mceRtZ4TipYSPmaONaiWoAU2VvwEIg==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.7",
+        "@temporalio/common": "1.11.3",
+        "@temporalio/proto": "1.11.3",
+        "abort-controller": "^3.0.0",
+        "long": "^5.2.3",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/@temporalio/common": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.11.3.tgz",
+      "integrity": "sha512-dzCrwiE9ox/Q16AjBsUKr4djg1ovYHNCjH36WZadwsemXINRWa5eW53j0WZOlmFF8/CbcHIhiD5N18rZqjiYkg==",
+      "dependencies": {
+        "@temporalio/proto": "1.11.3",
+        "long": "^5.2.3",
+        "ms": "^3.0.0-canary.1",
+        "proto3-json-serializer": "^2.0.0"
+      }
+    },
+    "node_modules/@temporalio/common/node_modules/ms": {
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
+      }
+    },
+    "node_modules/@temporalio/proto": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.11.3.tgz",
+      "integrity": "sha512-X+xV75m11BvvS5MljagtYCybRNxpLNJM24eWyfv+uyU4WZSvgQCUh21fY4FOUDJS66DPvO1mefSPu0Nunp1PHg==",
+      "dependencies": {
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.5"
       }
     },
     "node_modules/@textlint/ast-node-types": {
@@ -9527,6 +9691,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -9578,6 +9747,11 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/longest-streak": {
       "version": "2.0.4",
@@ -11237,6 +11411,40 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -13632,7 +13840,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@discordjs/rest": "^1.7.0",
     "@notionhq/client": "^2.2.3",
     "@sentry/node": "^7.50.0",
+    "@temporalio/client": "^1.11.3",
     "@togethercrew.dev/db": "^3.0.72",
     "@togethercrew.dev/tc-messagebroker": "^0.0.50",
     "@types/express-session": "^1.17.7",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,8 +55,9 @@ const envVarsSchema = Joi.object()
     REDIS_HOST: Joi.string().required().description('Redis host'),
     REDIS_PORT: Joi.string().required().description('Redis port'),
     REDIS_PASSWORD: Joi.string().required().description('Reids password').allow(''),
-    DISCOURSE_EXTRACTION_URL: Joi.string().required().description('Discourse extraction url'),
     OCI_BACKEND_URL: Joi.string().required().description('Oci Backend url'),
+    TEMPORAL_URI: Joi.string().required().description('Temporal address'),
+    TEMPORAL_QUEUE_HEAVY: Joi.string().required().description('Queue for heavy workflows'),
   })
   .unknown();
 
@@ -156,8 +157,9 @@ export default {
   session: {
     secret: envVars.SESSION_SECRET,
   },
-  discourse: {
-    extractionURL: envVars.DISCOURSE_EXTRACTION_URL,
+  temporal: {
+    uri: envVars.TEMPORAL_URI,
+    heavyQueue: envVars.TEMPORAL_QUEUE_HEAVY,
   },
   ociBackendURL: envVars.OCI_BACKEND_URL,
 };

--- a/src/services/discourse/core.service.ts
+++ b/src/services/discourse/core.service.ts
@@ -21,7 +21,7 @@ async function getPropertyHandler(req: IAuthAndPlatform) {
 async function createDiscourseSchedule(platformId: string, endpoint: string): Promise<string> {
   try {
     const schedule = await temporalDiscourse.createSchedule(platformId, endpoint);
-    logger.info(`Started schedule '${schedule.scheduleId}`);
+    logger.info(`Started schedule '${schedule.scheduleId}'`);
     return schedule.scheduleId;
   } catch (error) {
     logger.error(error, 'Failed to create discourse schedule');

--- a/src/services/discourse/core.service.ts
+++ b/src/services/discourse/core.service.ts
@@ -1,9 +1,8 @@
 import parentLogger from '../../config/logger';
 import { IAuthAndPlatform } from '../../interfaces';
 import categoryService from './category.service';
-import { ApiError, pick, sort } from '../../utils';
-import { Types } from 'mongoose';
-import config from '../../config';
+import { ApiError, pick } from '../../utils';
+import temporalDiscourse from '../temporal/discourse.service'
 const logger = parentLogger.child({ module: 'DiscourseCoreService' });
 
 async function getPropertyHandler(req: IAuthAndPlatform) {
@@ -19,31 +18,18 @@ async function getPropertyHandler(req: IAuthAndPlatform) {
  * @param {String} platformId
  * @returns {Promise<Void>}
  */
-async function runDiscourseExtraction(platformId: string): Promise<void> {
+async function createDiscourseSchedule(platformId: string, endpoint: string): Promise<string> {
   try {
-    const data = {
-      platform_id: platformId,
-    };
-    logger.debug(data);
-    const response = await fetch(config.discourse.extractionURL, {
-      method: 'POST',
-      body: JSON.stringify(data),
-      headers: { 'Content-Type': 'application/json' },
-    });
-    if (response.ok) {
-      logger.debug(await response.json());
-      return;
-    } else {
-      const errorResponse = await response.text();
-      logger.error({ error: errorResponse });
-    }
+    const schedule = await temporalDiscourse.createSchedule(platformId, endpoint)
+    console.log(`Started schedule '${schedule.scheduleId}`)
+    return schedule.scheduleId
   } catch (error) {
-    logger.error(error, 'Failed to run discourse extraction discourse');
-    throw new ApiError(590, 'Failed to run discourse extraction discourse');
+    logger.error(error, 'Failed to create discourse schedule');
+    throw new ApiError(590, 'Failed to create discourse schedule');
   }
 }
 
 export default {
   getPropertyHandler,
-  runDiscourseExtraction,
+  createDiscourseSchedule,
 };

--- a/src/services/discourse/core.service.ts
+++ b/src/services/discourse/core.service.ts
@@ -2,7 +2,7 @@ import parentLogger from '../../config/logger';
 import { IAuthAndPlatform } from '../../interfaces';
 import categoryService from './category.service';
 import { ApiError, pick } from '../../utils';
-import temporalDiscourse from '../temporal/discourse.service'
+import temporalDiscourse from '../temporal/discourse.service';
 const logger = parentLogger.child({ module: 'DiscourseCoreService' });
 
 async function getPropertyHandler(req: IAuthAndPlatform) {
@@ -20,9 +20,9 @@ async function getPropertyHandler(req: IAuthAndPlatform) {
  */
 async function createDiscourseSchedule(platformId: string, endpoint: string): Promise<string> {
   try {
-    const schedule = await temporalDiscourse.createSchedule(platformId, endpoint)
-    console.log(`Started schedule '${schedule.scheduleId}`)
-    return schedule.scheduleId
+    const schedule = await temporalDiscourse.createSchedule(platformId, endpoint);
+    logger.info(`Started schedule '${schedule.scheduleId}`);
+    return schedule.scheduleId;
   } catch (error) {
     logger.error(error, 'Failed to create discourse schedule');
     throw new ApiError(590, 'Failed to create discourse schedule');

--- a/src/services/discourse/core.service.ts
+++ b/src/services/discourse/core.service.ts
@@ -22,6 +22,7 @@ async function createDiscourseSchedule(platformId: string, endpoint: string): Pr
   try {
     const schedule = await temporalDiscourse.createSchedule(platformId, endpoint);
     logger.info(`Started schedule '${schedule.scheduleId}'`);
+    await schedule.trigger();
     return schedule.scheduleId;
   } catch (error) {
     logger.error(error, 'Failed to create discourse schedule');

--- a/src/services/platform.service.ts
+++ b/src/services/platform.service.ts
@@ -68,9 +68,12 @@ const getPlatformById = async (id: Types.ObjectId): Promise<HydratedDocument<IPl
 const callExtractionApp = async (platform: HydratedDocument<IPlatform>): Promise<void> => {
   switch (platform.name) {
     case PlatformNames.Discourse: {
-      const scheduleId = await discourseService.coreService.createDiscourseSchedule(platform.id as string, platform.metadata?.id as string);
-      platform.set('metadata.scheduleId', scheduleId)
-      await platform.save()
+      const scheduleId = await discourseService.coreService.createDiscourseSchedule(
+        platform.id as string,
+        platform.metadata?.id as string,
+      );
+      platform.set('metadata.scheduleId', scheduleId);
+      await platform.save();
       return;
     }
     default: {

--- a/src/services/platform.service.ts
+++ b/src/services/platform.service.ts
@@ -65,10 +65,12 @@ const getPlatformById = async (id: Types.ObjectId): Promise<HydratedDocument<IPl
  * @param {HydratedDocument<IPlatform>} platform
  * @returns {Promise<Void>}
  */
-const callExtractionApp = (platform: HydratedDocument<IPlatform>): void => {
+const callExtractionApp = async (platform: HydratedDocument<IPlatform>): Promise<void> => {
   switch (platform.name) {
     case PlatformNames.Discourse: {
-      discourseService.coreService.runDiscourseExtraction(platform.id as string);
+      const scheduleId = await discourseService.coreService.createDiscourseSchedule(platform.id as string, platform.metadata?.id as string);
+      platform.set('metadata.scheduleId', scheduleId)
+      await platform.save()
       return;
     }
     default: {

--- a/src/services/temporal/core.service.ts
+++ b/src/services/temporal/core.service.ts
@@ -1,0 +1,20 @@
+import { Client, Connection } from '@temporalio/client';
+import config from '../../config';
+
+export class TemporalCoreService {
+  private connection: Connection | undefined
+  private client: Client | undefined
+
+  constructor() { }
+
+  protected async getClient(): Promise<Client> {
+    if (!this.client) {
+      if (!this.connection) {
+        this.connection = await Connection.connect({ address: config.temporal.uri });
+      }
+      this.client = new Client({ connection: this.connection })
+    }
+    return this.client
+  }
+
+}

--- a/src/services/temporal/core.service.ts
+++ b/src/services/temporal/core.service.ts
@@ -2,19 +2,32 @@ import { Client, Connection } from '@temporalio/client';
 import config from '../../config';
 
 export class TemporalCoreService {
-  private connection: Connection | undefined
-  private client: Client | undefined
+  private connection: Connection | undefined;
+  private client: Client | undefined;
 
-  constructor() { }
+  private async createConnection(): Promise<Connection> {
+    try {
+      return await Connection.connect({ address: config.temporal.uri });
+    } catch (error) {
+      throw new Error(`Failed to connect to Temporal: ${(error as Error).message}`);
+    }
+  }
 
   protected async getClient(): Promise<Client> {
     if (!this.client) {
       if (!this.connection) {
-        this.connection = await Connection.connect({ address: config.temporal.uri });
+        this.connection = await this.createConnection();
       }
-      this.client = new Client({ connection: this.connection })
+      this.client = new Client({ connection: this.connection });
     }
-    return this.client
+    return this.client;
   }
 
+  public async disconnect(): Promise<void> {
+    if (this.connection) {
+      await this.connection.close();
+      this.connection = undefined;
+      this.client = undefined;
+    }
+  }
 }

--- a/src/services/temporal/discourse.service.ts
+++ b/src/services/temporal/discourse.service.ts
@@ -10,7 +10,7 @@ class TemporalDiscourseService extends TemporalCoreService {
         action: {
           type: 'startWorkflow',
           workflowType: 'DiscourseExtractWorkflow',
-          args: [endpoint], // TODO add platformId
+          args: [endpoint, platformId],
           taskQueue: config.temporal.heavyQueue,
         },
         scheduleId: `discourse/${encodeURIComponent(endpoint)}`,

--- a/src/services/temporal/discourse.service.ts
+++ b/src/services/temporal/discourse.service.ts
@@ -1,0 +1,29 @@
+import { Client, ScheduleHandle, ScheduleOverlapPolicy } from "@temporalio/client";
+import { TemporalCoreService } from "./core.service";
+import config from "src/config";
+
+class TemporalDiscourseService extends TemporalCoreService {
+
+  public async createSchedule(platformId: string, endpoint: string): Promise<ScheduleHandle> {
+    const client: Client = await this.getClient()
+
+    return client.schedule.create({
+      action: {
+        type: 'startWorkflow',
+        workflowType: 'DiscourseExtractWorkflow',
+        args: [endpoint], // add platformId
+        taskQueue: config.temporal.heavyQueue
+      },
+      scheduleId: `discourse/${endpoint}`,
+      policies: {
+        catchupWindow: '1 day',
+        overlap: ScheduleOverlapPolicy.ALLOW_ALL
+      },
+      spec: {
+        intervals: [{ every: '1d' }]
+      }
+    })
+  }
+}
+
+export default new TemporalDiscourseService()

--- a/src/services/temporal/discourse.service.ts
+++ b/src/services/temporal/discourse.service.ts
@@ -1,29 +1,28 @@
-import { Client, ScheduleHandle, ScheduleOverlapPolicy } from "@temporalio/client";
-import { TemporalCoreService } from "./core.service";
-import config from "src/config";
+import { Client, ScheduleHandle, ScheduleOverlapPolicy } from '@temporalio/client';
+import { TemporalCoreService } from './core.service';
+import config from 'src/config';
 
 class TemporalDiscourseService extends TemporalCoreService {
-
   public async createSchedule(platformId: string, endpoint: string): Promise<ScheduleHandle> {
-    const client: Client = await this.getClient()
+    const client: Client = await this.getClient();
 
     return client.schedule.create({
       action: {
         type: 'startWorkflow',
         workflowType: 'DiscourseExtractWorkflow',
-        args: [endpoint], // add platformId
-        taskQueue: config.temporal.heavyQueue
+        args: [endpoint], // TODO add platformId
+        taskQueue: config.temporal.heavyQueue,
       },
-      scheduleId: `discourse/${endpoint}`,
+      scheduleId: `discourse/${encodeURIComponent(endpoint)}`,
       policies: {
         catchupWindow: '1 day',
-        overlap: ScheduleOverlapPolicy.ALLOW_ALL
+        overlap: ScheduleOverlapPolicy.SKIP,
       },
       spec: {
-        intervals: [{ every: '1d' }]
-      }
-    })
+        intervals: [{ every: '1d' }],
+      },
+    });
   }
 }
 
-export default new TemporalDiscourseService()
+export default new TemporalDiscourseService();

--- a/src/services/temporal/discourse.service.ts
+++ b/src/services/temporal/discourse.service.ts
@@ -4,24 +4,27 @@ import config from '../../config';
 
 class TemporalDiscourseService extends TemporalCoreService {
   public async createSchedule(platformId: string, endpoint: string): Promise<ScheduleHandle> {
-    const client: Client = await this.getClient();
-
-    return client.schedule.create({
-      action: {
-        type: 'startWorkflow',
-        workflowType: 'DiscourseExtractWorkflow',
-        args: [endpoint], // TODO add platformId
-        taskQueue: config.temporal.heavyQueue,
-      },
-      scheduleId: `discourse/${encodeURIComponent(endpoint)}`,
-      policies: {
-        catchupWindow: '1 day',
-        overlap: ScheduleOverlapPolicy.SKIP,
-      },
-      spec: {
-        intervals: [{ every: '1d' }],
-      },
-    });
+    try {
+      const client: Client = await this.getClient();
+      return client.schedule.create({
+        action: {
+          type: 'startWorkflow',
+          workflowType: 'DiscourseExtractWorkflow',
+          args: [endpoint], // TODO add platformId
+          taskQueue: config.temporal.heavyQueue,
+        },
+        scheduleId: `discourse/${encodeURIComponent(endpoint)}`,
+        policies: {
+          catchupWindow: '1 day',
+          overlap: ScheduleOverlapPolicy.SKIP,
+        },
+        spec: {
+          intervals: [{ every: '1d' }],
+        },
+      });
+    } catch (error) {
+      throw new Error(`Failed to create Temporal schedule: ${(error as Error).message}`);
+    }
   }
 }
 

--- a/src/services/temporal/discourse.service.ts
+++ b/src/services/temporal/discourse.service.ts
@@ -1,6 +1,6 @@
 import { Client, ScheduleHandle, ScheduleOverlapPolicy } from '@temporalio/client';
 import { TemporalCoreService } from './core.service';
-import config from 'src/config';
+import config from '../../config';
 
 class TemporalDiscourseService extends TemporalCoreService {
   public async createSchedule(platformId: string, endpoint: string): Promise<ScheduleHandle> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Temporal service for scheduling workflows related to Discourse.
	- Added configuration keys for Temporal integration: `TEMPORAL_URI` and `TEMPORAL_QUEUE_HEAVY`.
	- Updated the method for creating schedules in the Discourse service, now allowing for endpoint specification.
	- Added functionality to connect and manage connections to the Temporal service.

- **Bug Fixes**
	- Removed an unused configuration key, streamlining the setup process.

- **Documentation**
	- Updated the configuration schema to reflect new and removed keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->