### PR TITLE
delete temporal schedule for discourse.

### DIFF
--- a/src/services/discourse/core.service.ts
+++ b/src/services/discourse/core.service.ts
@@ -25,12 +25,22 @@ async function createDiscourseSchedule(platformId: string, endpoint: string): Pr
     await schedule.trigger();
     return schedule.scheduleId;
   } catch (error) {
-    logger.error(error, 'Failed to create discourse schedule');
-    throw new ApiError(590, 'Failed to create discourse schedule');
+    logger.error(error, 'Failed to create discourse schedule.');
+    throw new ApiError(590, 'Failed to create discourse schedule.');
+  }
+}
+
+async function deleteDiscourseSchedule(scheduleId: string): Promise<void> {
+  try {
+    await temporalDiscourse.deleteSchedule(scheduleId);
+  } catch (error) {
+    logger.error(error, 'Failed to delete discourse schedule.');
+    throw new ApiError(590, 'Failed to delete discourse schedule.');
   }
 }
 
 export default {
   getPropertyHandler,
   createDiscourseSchedule,
+  deleteDiscourseSchedule,
 };

--- a/src/services/platform.service.ts
+++ b/src/services/platform.service.ts
@@ -144,6 +144,15 @@ const updatePlatform = async (
  * @returns {Promise<HydratedDocument<IPlatform>>}
  */
 const deletePlatform = async (platform: HydratedDocument<IPlatform>): Promise<HydratedDocument<IPlatform>> => {
+  switch (platform.name) {
+    case PlatformNames.Discourse: {
+      if (platform.metadata?.scheduleId) {
+        await discourseService.coreService.deleteDiscourseSchedule(platform.metadata.scheduleId);
+      }
+    }
+    default: {
+    }
+  }
   return await platform.remove();
 };
 
@@ -157,7 +166,7 @@ const deletePlatformByFilter = async (filter: object): Promise<HydratedDocument<
   if (!platform) {
     throw new ApiError(httpStatus.NOT_FOUND, 'Platform not found');
   }
-  return await platform.remove();
+  return await deletePlatform(platform);
 };
 
 function getMetadataKey(platformName: string): string {

--- a/src/services/temporal/discourse.service.ts
+++ b/src/services/temporal/discourse.service.ts
@@ -26,6 +26,18 @@ class TemporalDiscourseService extends TemporalCoreService {
       throw new Error(`Failed to create Temporal schedule: ${(error as Error).message}`);
     }
   }
+
+  public async pauseSchedule(scheduleId: string): Promise<void> {
+    const client: Client = await this.getClient();
+    const handle = client.schedule.getHandle(scheduleId);
+    await handle.pause();
+  }
+
+  public async deleteSchedule(scheduleId: string): Promise<void> {
+    const client: Client = await this.getClient();
+    const handle = client.schedule.getHandle(scheduleId);
+    await handle.delete();
+  }
 }
 
 export default new TemporalDiscourseService();


### PR DESCRIPTION
Adds the function of deleting the temporal schedule associated with the discourse extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a function to delete discourse schedules by their ID.
	- Added methods to pause and delete schedules within the Temporal Discourse service.
	- Enhanced platform deletion logic to handle associated discourse schedules.

- **Bug Fixes**
	- Improved error logging for schedule creation.

These changes enhance the management of discourse schedules and streamline platform deletions, improving overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->