### PR TITLE
Mediawiki changes

### DIFF
--- a/src/docs/module.doc.yml
+++ b/src/docs/module.doc.yml
@@ -241,10 +241,13 @@ paths:
                                 description: Metadata for the hivemind module on Notion.
                               - type: object
                                 properties:
-                                  pageIds:
+                                  namespaces:
                                     type: array
                                     items:
-                                      type: string
+                                      type: number
+                                    default: [0]
+                                  activated:
+                                    type: boolean
                                 description: Metadata for the hivemind module on MediaWiki.
                               - type: object
                                 description: Metadata for the hivemind module on website.

--- a/src/docs/platform.doc.yml
+++ b/src/docs/platform.doc.yml
@@ -165,16 +165,17 @@ paths:
                                   type: string
                       description: Metadata for Notion.
                     - type: object
-                      required: [baseURL, path, namespaces]
+                      required: [baseURL, path]
                       properties:
                         baseURL:
                           type: string
                         path:
                           type: string
                         namespaces:
-                          type: array 
+                          type: array
                           items:
                             type: number
+                          default: [0]
                       description: Metadata for MediaWiki.
                     - type: object
                       required: [id, period, analyzerStartedAt, resources]

--- a/src/validations/module.validation.ts
+++ b/src/validations/module.validation.ts
@@ -1,7 +1,10 @@
 import Joi from 'joi';
 
 import {
-    HivemindPlatformNames, ModuleNames, PlatformNames, ViolationDetectionPlatformNames
+  HivemindPlatformNames,
+  ModuleNames,
+  PlatformNames,
+  ViolationDetectionPlatformNames,
 } from '@togethercrew.dev/db';
 
 import { objectId } from './custom.validation';

--- a/src/validations/module.validation.ts
+++ b/src/validations/module.validation.ts
@@ -1,10 +1,7 @@
 import Joi from 'joi';
 
 import {
-  HivemindPlatformNames,
-  ModuleNames,
-  PlatformNames,
-  ViolationDetectionPlatformNames,
+    HivemindPlatformNames, ModuleNames, PlatformNames, ViolationDetectionPlatformNames
 } from '@togethercrew.dev/db';
 
 import { objectId } from './custom.validation';
@@ -79,6 +76,7 @@ const hivemindNotionMetadata = () => {
 
 const hivemindMediaWikiMetadata = () => {
   return Joi.object().keys({
+    namespaces: Joi.array().items(Joi.number()).default([0]),
     activated: Joi.boolean(),
   });
 };

--- a/src/validations/platform.validation.ts
+++ b/src/validations/platform.validation.ts
@@ -39,7 +39,7 @@ const mediaWikiUpdateMetadata = () => {
   return Joi.object().keys({
     baseURL: Joi.string().required(),
     path: Joi.string().required(),
-    namespaces: Joi.array().items(Joi.number()).required(),
+    namespaces: Joi.array().items(Joi.number()).default([0]),
   });
 };
 
@@ -94,7 +94,7 @@ const mediaWikiMetadata = () => {
   return Joi.object().keys({
     baseURL: Joi.string().required(),
     path: Joi.string().required(),
-    namespaces: Joi.array().items(Joi.number()).required(),
+    namespaces: Joi.array().items(Joi.number()).default([0]),
   });
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new optional "activated" setting for the MediaWiki module metadata.

- **Bug Fixes**
  - The "namespaces" field for MediaWiki metadata is now optional and defaults to [0] if not provided.

- **Documentation**
  - Updated API documentation to reflect changes in MediaWiki module and platform metadata fields, including the renaming and default value for "namespaces" and the addition of "activated".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->